### PR TITLE
Improve kubelet too many pods alert

### DIFF
--- a/rules/kubelet.libsonnet
+++ b/rules/kubelet.libsonnet
@@ -18,6 +18,19 @@
             },
           }
           for quantile in ['0.99', '0.9', '0.5']
+        ] + [
+          {
+            record: 'node_type:kube_node_status_capacity_pods_unless_unschedulable:sum',
+            expr: |||
+              sum by (node_type) (label_replace(kube_node_status_capacity_pods{job="kube-state-metrics"} unless kube_node_spec_unschedulable{job="kube-state-metrics"} == 1, "node_type", "$1", "node", "([^0-9]+)[0-9].*"))
+            |||,
+          },
+          {
+            record: 'node_type:kube_pod_info:count',
+            expr: |||
+              count by (node_type) (label_replace(kube_pod_info{job="kube-state-metrics"}, "node_type", "$1", "node", "([^0-9]+)[0-9].*"))
+            |||,
+          },
         ],
       },
     ],

--- a/tests.yaml
+++ b/tests.yaml
@@ -82,19 +82,15 @@ tests:
 
 - interval: 1m
   input_series:
-  - series: 'kube_node_status_capacity_pods{instance="172.17.0.5:8443",node="minikube",job="kube-state-metrics", namespace="kube-system"}'
+  - series: 'kube_node_status_capacity_pods{instance="172.17.0.5:8443",node="worker01",job="kube-state-metrics", namespace="kube-system"}'
     values: '3+0x15'
-  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="minikube",pod="pod-1",service="kube-state-metrics"}'
+  - series: 'kube_node_spec_unschedulable{instance="172.17.0.5:8443",node="worker01",job="kube-state-metrics", namespace="kube-system"}'
+    values: '0+0x15'
+  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-1",service="kube-state-metrics"}'
     values: '1+0x15'
-  - series: 'kube_pod_status_phase{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",phase="Running",pod="pod-1",service="kube-state-metrics"}'
+  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-2",service="kube-state-metrics"}'
     values: '1+0x15'
-  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="minikube",pod="pod-2",service="kube-state-metrics"}'
-    values: '1+0x15'
-  - series: 'kube_pod_status_phase{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",phase="Running",pod="pod-2",service="kube-state-metrics"}'
-    values: '1+0x15'
-  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="minikube",pod="pod-3",service="kube-state-metrics"}'
-    values: '1+0x15'
-  - series: 'kube_pod_status_phase{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",phase="Running",pod="pod-3",service="kube-state-metrics"}'
+  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-3",service="kube-state-metrics"}'
     values: '1+0x15'
   alert_rule_test:
   - eval_time: 10m
@@ -103,11 +99,11 @@ tests:
     alertname: KubeletTooManyPods
     exp_alerts:
     - exp_labels:
-        node: minikube
+        node_type: worker
         severity: warning
       exp_annotations:
-        summary: "Kubelet is running at capacity."
-        description: "Kubelet 'minikube' is running at 100% of its Pod capacity."
+        summary: "Kubelets are running at capacity."
+        description: "Kubelets of worker pool of type 'worker' exhaust 100% of their configured pod limits."
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
 
 - interval: 1m

--- a/tests.yaml
+++ b/tests.yaml
@@ -83,15 +83,42 @@ tests:
 - interval: 1m
   input_series:
   - series: 'kube_node_status_capacity_pods{instance="172.17.0.5:8443",node="worker01",job="kube-state-metrics", namespace="kube-system"}'
-    values: '3+0x15'
-  - series: 'kube_node_spec_unschedulable{instance="172.17.0.5:8443",node="worker01",job="kube-state-metrics", namespace="kube-system"}'
+    values: '2+0x15'
+  - series: 'kube_node_status_capacity_pods{instance="152.17.0.5:8443",node="worker02",job="kube-state-metrics", namespace="kube-system"}'
+    values: '2+0x15'
+  - series: 'kube_node_spec_unschedulable{instance="152.17.0.5:8443",node="worker01",job="kube-state-metrics", namespace="kube-system"}'
     values: '0+0x15'
-  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-1",service="kube-state-metrics"}'
+  - series: 'kube_node_spec_unschedulable{instance="152.17.0.5:8443",node="worker02",job="kube-state-metrics", namespace="kube-system"}'
     values: '1+0x15'
-  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-2",service="kube-state-metrics"}'
+  - series: 'kube_pod_info{endpoint="https-main",instance="152.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-1",service="kube-state-metrics"}'
     values: '1+0x15'
-  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-3",service="kube-state-metrics"}'
+  - series: 'kube_pod_info{endpoint="https-main",instance="152.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="worker01",pod="pod-2",service="kube-state-metrics"}'
     values: '1+0x15'
+  - series: 'kube_node_status_capacity_pods{instance="152.17.0.5:8443",node="master01",job="kube-state-metrics", namespace="kube-system"}'
+    values: '2+0x15'
+  - series: 'kube_node_status_capacity_pods{instance="152.17.0.5:8443",node="master02",job="kube-state-metrics", namespace="kube-system"}'
+    values: '2+0x15'
+  - series: 'kube_node_spec_unschedulable{instance="152.17.0.5:8443",node="master01",job="kube-state-metrics", namespace="kube-system"}'
+    values: '0+0x15'
+  - series: 'kube_node_spec_unschedulable{instance="152.17.0.5:8443",node="master02",job="kube-state-metrics", namespace="kube-system"}'
+    values: '0+0x15'
+  - series: 'kube_pod_info{endpoint="https-main",instance="152.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="master01",pod="master-pod-1",service="kube-state-metrics"}'
+    values: '1+0x15'
+  - series: 'kube_pod_info{endpoint="https-main",instance="152.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="master02",pod="master-pod-2",service="kube-state-metrics"}'
+    values: '1+0x15'
+  promql_expr_test:
+  - expr: 'node_type:kube_node_status_capacity_pods_unless_unschedulable:sum'
+    exp_samples:
+    - labels: 'node_type:kube_node_status_capacity_pods_unless_unschedulable:sum{node_type="worker"}'
+      value: 2
+    - labels: 'node_type:kube_node_status_capacity_pods_unless_unschedulable:sum{node_type="master"}'
+      value: 4
+  - expr: 'node_type:kube_pod_info:count'
+    exp_samples:
+    - labels: 'node_type:kube_pod_info:count{node_type="worker"}'
+      value: 2
+    - labels: 'node_type:kube_pod_info:count{node_type="master"}'
+      value: 2
   alert_rule_test:
   - eval_time: 10m
     alertname: KubeletTooManyPods


### PR DESCRIPTION
Don't warn, when single nodes have above 95% of their pod capacity scheduled, but when the nodes consume >80% of the capacity.

Distinguish between node types (node name prefix).