### PR TITLE
Fix: kubelet & proxy dashboards in big clusters

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -364,6 +364,7 @@ local singlestat = grafana.singlestat;
           'label_values(kubelet_runtime_operations_total{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, instance)' % $._config,
           refresh='time',
           includeAll=true,
+          allValues='.+',
           sort=1,
         )
       )

--- a/dashboards/proxy.libsonnet
+++ b/dashboards/proxy.libsonnet
@@ -162,6 +162,7 @@ local singlestat = grafana.singlestat;
           'label_values(kubeproxy_network_programming_duration_seconds_bucket{%(kubeProxySelector)s}, instance)' % $._config,
           refresh='time',
           includeAll=true,
+          allValues='.+',
           sort=1,
         )
       )


### PR DESCRIPTION
Too many instances generate too long URLs.